### PR TITLE
initialFields example

### DIFF
--- a/examples/validation/src/components/Input.js
+++ b/examples/validation/src/components/Input.js
@@ -6,32 +6,42 @@ type InputProps = {
   value: any,
   updateField: Function,
   validate?: Function,
+  isRequired: boolean,
+  isTouched: boolean,
   isValid: boolean,
-  fieldId: string
+  placeholder: string,
 }
 
 const Input = ({
   updateField,
   value,
+  isRequired,
+  isTouched,
   isValid,
-  fieldId,
+  placeholder,
   validate = () => true
 }: InputProps) => {
-  function onInput(e) {
-    const newValue = e.target.value
+  function onChange(e) {
+    const newValue = e.target.value;
 
     updateField({
       value: newValue,
       isValid: validate(newValue)
-    })
+    });
   }
 
   return (
     <input
       value={value}
-      onInput={onInput}
-      placeholder={fieldId}
-      style={{ backgroundColor: isValid ? 'inherit' : 'red' }}
+      onChange={onChange}
+      placeholder={placeholder}
+      required={isRequired}
+      style={{
+        backgroundColor: isTouched && !isValid ? 'red' : 'inherit',
+        display: 'block',
+        marginBottom: '1em',
+        marginTop: '0.5em',
+      }}
     />
   )
 }

--- a/examples/validation/src/index.js
+++ b/examples/validation/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import { Form, mapDataToValues } from 'react-controlled-form'
+import { Form, mapDataToValues, validateWithRequired } from 'react-controlled-form'
 
 import Submit from './components/Submit'
 import Input from './components/Input'
@@ -14,20 +14,42 @@ function onSubmit({ data, resetForm }) {
   resetForm()
 }
 
+const initialFields = {
+  name: {
+    isTouched: true,
+    isValid: true,
+    value: "Prepopulated",
+  },
+  age: {
+    isValid: false,
+  }
+};
+
 const render = () =>
   ReactDOM.render(
     <Provider store={store}>
-      <Form formId="validation" onSubmit={onSubmit}>
+      <Form formId="validation" initialFields={initialFields} onSubmit={onSubmit}>
         <div>
           <h1>Validation Example</h1>
-          <br />
+          <label>Name&#42;</label>
           <Input
             fieldId="name"
-            validate={value => value.match(/^[a-zA-z]*$/) !== null}
+            isRequired
+            placeholder="Prepopulated required field"
+            validate={value => validateWithRequired(value, true) && value.match(/^[a-zA-z]*$/) !== null}
           />
+          <label>Age&#42;</label>
           <Input
             fieldId="age"
-            validate={value => value.match(/^[0-9]*$/) !== null}
+            isRequired
+            placeholder="Required field"
+            validate={value => validateWithRequired(value, true) && value.match(/^[0-9]*$/) !== null}
+          />
+          <label>Description</label>
+          <Input
+            fieldId="description"
+            placeholder="Optional field"
+            validate={value => value.match(/^[a-zA-z]*$/) !== null}
           />
           <Submit />
           <br />

--- a/modules/components/Form.js
+++ b/modules/components/Form.js
@@ -134,6 +134,7 @@ class Form extends Component {
       onChange,
       data,
       state,
+      initialFields,
       initForm,
       updateField,
       updateState,

--- a/modules/components/Form.js
+++ b/modules/components/Form.js
@@ -134,7 +134,6 @@ class Form extends Component {
       onChange,
       data,
       state,
-      initialFields,
       initForm,
       updateField,
       updateState,


### PR DESCRIPTION
Change the validation example to show a slightly more complex, real-life form.

* Add required and prepopulated field examples
* Include usage of `validateWithRequired` and `initialFields`

Note: `onInput` changed to `onChange` because otherwise React throws an error when a `value` is included in `initialFields`. (`onChange` is required when a `value` is present.)