### PR TITLE
Hotfix #39 - Field renders limited by shouldComponentUpdate

### DIFF
--- a/modules/components/Field.js
+++ b/modules/components/Field.js
@@ -3,6 +3,7 @@ import { Component } from 'react'
 import PropTypes from 'prop-types'
 import { getContext, compose } from 'recompose'
 import { connect } from 'react-redux'
+import rfc from 'react-fast-compare'
 
 import { mapStateToProps, mapDispatchToProps } from '../mapping/field'
 
@@ -34,6 +35,16 @@ class Field extends Component {
     const init = () => initField(initialData, initialState)
     this.unsubscribe = subscribeToReinit(init)
     init()
+  }
+  
+  // Hotfix for https://github.com/rofrischmann/react-controlled-form/issues/39
+  shouldComponentUpdate(nextProps, nextState) {
+    const sameState = rfc(this.state, nextState)
+    const sameFormState = rfc(this.props.state, nextProps.state)
+    const sameData = rfc(this.props.data, nextProps.data)
+    const sameId = this.props.formId === nextProps.formId
+
+    return !(sameState && sameFormState && sameData && sameId)
   }
 
   componentWillUnmount() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-controlled-form",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Controlled Forms for React and Redux",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -47,6 +47,7 @@
   "dependencies": {
     "fast-loops": "^1.0.0",
     "prop-types": "^15.5.10",
+    "react-fast-compare": "^2.0.2",
     "recompose": "^0.23.5",
     "redux-actions": "^2.0.3"
   },


### PR DESCRIPTION
Related to #39 

Could not apply the same problem resultion method to Form, since initialization fails in the tests, likely due to something happening in ComponentWillReceiveProps