### PR TITLE
Temp fix for re-rendering issues with Field (#39)

### DIFF
--- a/modules/components/Field.js
+++ b/modules/components/Field.js
@@ -39,55 +39,47 @@ class Field extends Component {
   
   // Hotfix for https://github.com/rofrischmann/react-controlled-form/issues/39
   shouldComponentUpdate(nextProps, nextState) {
-    console.log(`${this.props.formId}.${this.props.fieldId} SCU`);
-    
+    // See https://github.com/facebook/react/issues/12185#issuecomment-364531032
     if (this.props.children !== nextProps.children) {
       return true
     }
+    const diffRF = this.props.render === nextProps.render;
+    if (diffRF) {
+      return true
+    }
+    // Deep equalities
+    const diffState = rfc(this.state, nextState)
+    if (diffState) {
+      return true
+    }
+    const diffFormState = rfc(this.props.state, nextProps.state)
+    if (diffFormState) {
+      return true
+    }
+    const diffData = rfc(this.props.data, nextProps.data)
+    if (diffData) {
+      return true
+    }
+    // Shallow ones
+    const diffFormId = this.props.formId === nextProps.formId
+    if (diffFormId) {
+      return true
+    }
+    const diffFieldId = this.props.fieldId === nextProps.fieldId
+    if (diffFieldId) {
+      return true
+    }
+    const diffInitData = this.props.initialData !== nextProps.initialData
+    if (diffInitData) {
+      return true
+    }
+    const diffInitState = this.props.initialState !== nextProps.initialState
+    if (diffInitState) {
+      return true
+    }
     
-    const sameRF = this.props.render === nextProps.render;
-    if (!sameRF) {
-      console.log('Render function differs!')
-      return true
-    }
-    const sameState = rfc(this.state, nextState)
-    if (!sameState) {
-      console.log('State differs!')
-      return true
-    }
-    const sameFormState = rfc(this.props.state, nextProps.state)
-    if (!sameFormState) {
-      console.log('FormState differs!')
-      return true
-    }
-    const sameData = rfc(this.props.data, nextProps.data)
-    if (!sameData) {
-      console.log('Form Data prop differs!')
-      return true
-    }
-    const sameFormId = this.props.formId === nextProps.formId
-    if (!sameFormId) {
-      console.log('formId differs!')
-      return true
-    }
-    const sameFieldId = this.props.fieldId === nextProps.fieldId
-    if (!sameFieldId) {
-      console.log('fieldId differs!')
-      return true
-    }
-  
-    if (this.props.initialData !== nextProps.initialData) {
-      console.log('initialData differs!')
-      return true
-    }
-    if (this.props.initialState !== nextProps.initialState) {
-      console.log('initialState differs!')
-      return true
-    }
-  
-    console.log(`${this.props.formId}.${this.props.fieldId} NO NEED TO UPDATE`);
+    // No need to update.
     return false;
-    // return !(sameState && sameFormState && sameData && sameId)
   }
 
   componentWillUnmount() {

--- a/modules/components/Field.js
+++ b/modules/components/Field.js
@@ -39,12 +39,55 @@ class Field extends Component {
   
   // Hotfix for https://github.com/rofrischmann/react-controlled-form/issues/39
   shouldComponentUpdate(nextProps, nextState) {
+    console.log(`${this.props.formId}.${this.props.fieldId} SCU`);
+    
+    if (this.props.children !== nextProps.children) {
+      return true
+    }
+    
+    const sameRF = this.props.render === nextProps.render;
+    if (!sameRF) {
+      console.log('Render function differs!')
+      return true
+    }
     const sameState = rfc(this.state, nextState)
+    if (!sameState) {
+      console.log('State differs!')
+      return true
+    }
     const sameFormState = rfc(this.props.state, nextProps.state)
+    if (!sameFormState) {
+      console.log('FormState differs!')
+      return true
+    }
     const sameData = rfc(this.props.data, nextProps.data)
-    const sameId = this.props.formId === nextProps.formId
-
-    return !(sameState && sameFormState && sameData && sameId)
+    if (!sameData) {
+      console.log('Form Data prop differs!')
+      return true
+    }
+    const sameFormId = this.props.formId === nextProps.formId
+    if (!sameFormId) {
+      console.log('formId differs!')
+      return true
+    }
+    const sameFieldId = this.props.fieldId === nextProps.fieldId
+    if (!sameFieldId) {
+      console.log('fieldId differs!')
+      return true
+    }
+  
+    if (this.props.initialData !== nextProps.initialData) {
+      console.log('initialData differs!')
+      return true
+    }
+    if (this.props.initialState !== nextProps.initialState) {
+      console.log('initialState differs!')
+      return true
+    }
+  
+    console.log(`${this.props.formId}.${this.props.fieldId} NO NEED TO UPDATE`);
+    return false;
+    // return !(sameState && sameFormState && sameData && sameId)
   }
 
   componentWillUnmount() {

--- a/modules/components/Field.js
+++ b/modules/components/Field.js
@@ -3,6 +3,7 @@ import { Component } from 'react'
 import PropTypes from 'prop-types'
 import { getContext, compose } from 'recompose'
 import { connect } from 'react-redux'
+import rfc from 'react-fast-compare'
 
 import { mapStateToProps, mapDispatchToProps } from '../mapping/field'
 
@@ -34,6 +35,16 @@ class Field extends Component {
     const init = () => initField(initialData, initialState)
     this.unsubscribe = subscribeToReinit(init)
     init()
+  }
+  
+  // Hotfix for https://github.com/rofrischmann/react-controlled-form/issues/39
+  shouldComponentUpdate(nextProps, nextState) {
+    const sameState = rfc(this.state, nextState)
+    const sameFormState = rfc(this.props.state, nextProps.state)
+    const sameData = rfc(this.props.data, nextProps.data)
+    const sameId = this.props.formId === nextProps.formId
+
+    return !(sameState && sameFormState && sameData && sameId)
   }
 
   componentWillUnmount() {

--- a/modules/mapping/field.js
+++ b/modules/mapping/field.js
@@ -21,6 +21,11 @@ export function mapStateToProps(store: Object, { fieldId, formId }: Object) {
   }
 }
 
+// https://github.com/reduxjs/react-redux/issues/157#issuecomment-148333201
+// https://stackoverflow.com/questions/46911024/how-do-i-avoid-re-rendering-a-connected-react-purecomponent-due-to-mapdispatchto/46918014#46918014
+// Passing ownProps to the mapDispatchToProps was forcing the component
+// to re-render on every interaction with the redux store, even unrelated to it,
+// as the function changed every time and thus were not cached.
 export function mapDispatchToProps(
   dispatch: Function,
   { fieldId, formId }: Object

--- a/modules/mapping/form.js
+++ b/modules/mapping/form.js
@@ -33,6 +33,11 @@ export function mapStateToProps(store: Object, { formId }: Object) {
   }
 }
 
+// https://github.com/reduxjs/react-redux/issues/157#issuecomment-148333201
+// https://stackoverflow.com/questions/46911024/how-do-i-avoid-re-rendering-a-connected-react-purecomponent-due-to-mapdispatchto/46918014#46918014
+// Passing ownProps to the mapDispatchToProps was forcing the component
+// to re-render on every interaction with the redux store, even unrelated to it,
+// as the function changed every time and thus were not cached.
 export function mapDispatchToProps(dispatch: Function, { formId }: Object) {
   return {
     initForm: (initialFields: Object, initialState: Object) =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-controlled-form",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Controlled Forms for React and Redux",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-controlled-form",
-  "version": "3.2.1",
+  "version": "3.2.5",
   "description": "Controlled Forms for React and Redux",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -12,7 +12,7 @@
     "es/**"
   ],
   "scripts": {
-    "build": "BABEL_ENV=commonjs babel -d lib modules && babel -d es modules",
+    "build": "cross-env BABEL_ENV=commonjs babel -d lib modules && babel -d es modules",
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean --yes",
     "clear": "rimraf coverage _book lib es",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-controlled-form",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Controlled Forms for React and Redux",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -47,6 +47,7 @@
   "dependencies": {
     "fast-loops": "^1.0.0",
     "prop-types": "^15.5.10",
+    "react-fast-compare": "^2.0.2",
     "recompose": "^0.23.5",
     "redux-actions": "^2.0.3"
   },


### PR DESCRIPTION
A quick hotfix for the re-rendering issues with Field Component detailed in https://github.com/rofrischmann/react-controlled-form/issues/39

I would not suggest it as a long term solution, but it is a stopgap measure until the mapping for Field and Form are rewritten in a way to avoid relying on the use of the ownProps parameter in the mapDispatchToProps.